### PR TITLE
Add missing hyphen to encoding specifier

### DIFF
--- a/hide_my_python.py
+++ b/hide_my_python.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# 	-*- coding: utf8 -*-
+# 	-*- coding: utf-8 -*-
 #
 # 	HideMyPython! - A parser for the free proxy list on HideMyAss!
 #
@@ -7,17 +7,17 @@
 #	It parses the arguments, creates a database, and save the proxies.
 #
 # 	Copyright (C) 2013 Yannick Méheut <useless (at) utouch (dot) fr>
-# 
+#
 # 	This program is free software: you can redistribute it and/or modify
 # 	it under the terms of the GNU General Public License as published by
 # 	the Free Software Foundation, either version 3 of the License, or
 # 	(at your option) any later version.
-# 
+#
 # 	This program is distributed in the hope that it will be useful,
 # 	but WITHOUT ANY WARRANTY; without even the implied warranty of
 # 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # 	GNU General Public License for more details.
-# 
+#
 # 	You should have received a copy of the GNU General Public License
 # 	along with this program.  If not, see <http://www.gnu.org/licenses/>.
 


### PR DESCRIPTION
Without hyphen it's wrong at least in windows. Here's what I got when tried to run script before the fix:
```
SyntaxError: encoding problem: utf-8
```